### PR TITLE
Issue_136474

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -771,7 +771,7 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 	}
 
 	public convertModelPositionToViewPosition(_modelLineNumber: number, _modelColumn: number, affinity: PositionAffinity = PositionAffinity.None): Position {
-		//Here
+	
 		const validPosition = this.model.validatePosition(new Position(_modelLineNumber, _modelColumn));
 		const inputLineNumber = validPosition.lineNumber;
 		const inputColumn = validPosition.column;
@@ -792,11 +792,11 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 		if (lineIndexChanged) {
 			r = this.modelLineProjections[lineIndex].getViewPositionOfModelPosition(deltaLineNumber, this.model.getLineMaxColumn(lineIndex + 1), affinity);
 		} else {
-			r = this.modelLineProjections[inputLineNumber - 1].getViewPositionOfModelPosition(deltaLineNumber, inputColumn, affinity);
+			r = this.modelLineProjections[deltaLineNumber - 1].getViewPositionOfModelPosition(deltaLineNumber, inputColumn, affinity);
 		}
 
+		return r
 		// console.log('in -> out ' + inputLineNumber + ',' + inputColumn + ' ===> ' + r.lineNumber + ',' + r);
-		return r;
 	}
 
 	/**

--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -771,7 +771,7 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 	}
 
 	public convertModelPositionToViewPosition(_modelLineNumber: number, _modelColumn: number, affinity: PositionAffinity = PositionAffinity.None): Position {
-
+		//Here
 		const validPosition = this.model.validatePosition(new Position(_modelLineNumber, _modelColumn));
 		const inputLineNumber = validPosition.lineNumber;
 		const inputColumn = validPosition.column;


### PR DESCRIPTION
Change to line 795 in viewModelLines.ts that replaces "lineIndex" to "deltaLineNumber". This fully underlines all of a wrapped line containing an opening bracket when the bracket is highlighted. 

This is an incomplete fix to issue #1367474. Further review and work required. 
